### PR TITLE
(upgrade): lister v9

### DIFF
--- a/delve-db.el
+++ b/delve-db.el
@@ -31,7 +31,8 @@
 
 ;; * Silence Byte Compiler
 
-(declare-function lister-replace "lister" (buf pos data &optional level) t)
+(declare-function lister-replace "lister" (ewoc pos data &optional level) t)
+(declare-function lister-get-ewoc "lister" (buf) t)
 
 ;; * Global Variables
 
@@ -89,7 +90,7 @@ This is a simple copy of dash's `-flatten' using `seq'."
   (when (derived-mode-p 'delve-mode)
     ;; TODO Move this out of this module; this should be handled in
     ;; delve main
-    (lister-replace (current-buffer) :point
+    (lister-replace (lister-get-ewoc (current-buffer)) :point
 		    (delve-make-error :message "Useless message"
 				      :buffer (get-buffer-create delve-db-error-buffer)))))
 


### PR DESCRIPTION
I have amended buffer centric operations with ewoc centric counterparts. Depends on https://github.com/publicimageltd/lister/pull/2
Delve still felts slow for me on 1000+ results but it is faster than before. I wager placing and displaying items one by one into ewoc would be feel faster because the user can interact with results as soon as they can be displayed.