### PR TITLE
Make remove-candidate-suffix match only last pair of parenthesis

### DIFF
--- a/delve.el
+++ b/delve.el
@@ -711,11 +711,9 @@ to the end, in parentheses.  To remove SUFFIX, use
 
 (defun delve--remove-candidate-suffix (cand)
   "Remove suffix in parentheses from CAND."
-  (replace-regexp-in-string (rx string-start
-                                (zero-or-more space)
-                                (group (*? nonl))
-                                (zero-or-more space)
-                                "(" (one-or-more nonl) ")")
+  (replace-regexp-in-string (rx (one-or-more space)
+                                "(" (+ (not ")")) ")"
+                                string-end)
                             "\\1"
                             cand))
 


### PR DESCRIPTION
The old regex works well as long as there is only a pair of
parenthesis but a string like
"\~/Dropbox (Maestral)/delve/note.delve (Open file)" would have
resulted in "\~/Dropbox".